### PR TITLE
Resolve overlapping tags when pulling an image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ clean:
 
 .PHONY: test
 test: $(CONFIG_GO)
-	@export GOOS=linux && go test -cover ./...
+	@export GOOS=linux && go test -v -cover ./...
 
 .PHONY: lint
 lint:

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -37,8 +37,8 @@ import (
 )
 
 const (
-	// ImageIDLen reflects number of symbols in image unique ID.
-	ImageIDLen = 64
+	// IDLen reflects number of symbols in image unique ID.
+	IDLen = 64
 )
 
 // Info represents image stored on host filesystem.

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -41,7 +41,7 @@ const (
 	IDLen = 64
 )
 
-// Info represents image stored on host filesystem.
+// Info represents image stored on the host filesystem.
 type Info struct {
 	id     string
 	sha256 string
@@ -55,6 +55,12 @@ func (i *Info) ID() string {
 	return i.id
 }
 
+// SetID sets desired image id. Should be used when
+// default ID (image sha256 checksum) doesn't fit needs.
+func (i *Info) SetID(id string) {
+	i.id = id
+}
+
 // Path returns path to image file.
 func (i *Info) Path() string {
 	return i.path
@@ -65,9 +71,16 @@ func (i *Info) Size() uint64 {
 	return i.size
 }
 
-// Ref returns associated image reference.,
+// Ref returns associated image reference.
 func (i *Info) Ref() *Reference {
 	return i.ref
+}
+
+// SetRef sets associated image reference. Should be used
+// in rare cases when one wishes to override Reference that
+// was used to pull image.
+func (i *Info) SetRef(ref *Reference) {
+	i.ref = ref
 }
 
 // MarshalJSON marshals Info into a valid JSON.

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -124,7 +124,7 @@ func TestPullImage(t *testing.T) {
 	}
 }
 
-func TestMatches(t *testing.T) {
+func TestInfo_Matches(t *testing.T) {
 	tt := []struct {
 		name   string
 		img    *Info
@@ -230,4 +230,46 @@ func TestMatches(t *testing.T) {
 			require.Equal(t, tc.expect, tc.img.Matches(tc.filter))
 		})
 	}
+}
+
+func TestInfo_UnmarshalJSON(t *testing.T) {
+	input := `
+{"id":"0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+"sha256":"0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+"size":741376,
+"path":"/var/lib/singularity/0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+"ref":{"uri":"docker","tags":["busybox:1.28"],"digests":null}}`
+
+	info := new(Info)
+	err := info.UnmarshalJSON([]byte(input))
+	require.NoError(t, err, "could not unmarshal image")
+	require.Equal(t, &Info{
+		id:     "0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+		sha256: "0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+		size:   741376,
+		path:   "/var/lib/singularity/0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+		ref: &Reference{
+			uri:  "docker",
+			tags: []string{"busybox:1.28"},
+		},
+	}, info)
+}
+
+func TestInfo_MarshalJSON(t *testing.T) {
+	expect := []byte(`{"id":"0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0","sha256":"0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0","size":741376,"path":"/var/lib/singularity/0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0","ref":{"uri":"docker","tags":["busybox:1.28"],"digests":null}}`)
+
+	info := &Info{
+		id:     "0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+		sha256: "0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+		size:   741376,
+		path:   "/var/lib/singularity/0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+		ref: &Reference{
+			uri:  "docker",
+			tags: []string{"busybox:1.28"},
+		},
+	}
+
+	res, err := info.MarshalJSON()
+	require.NoError(t, err, "could not marshal image")
+	require.Equal(t, expect, res)
 }

--- a/pkg/image/reference.go
+++ b/pkg/image/reference.go
@@ -171,7 +171,7 @@ func mergeStrSlice(t1, t2 []string) []string {
 }
 
 // removeFromSlice returns passed slice without first occurrence of element v.
-// It does not makes a copy of a passed slice.
+// It does not make a copy of a passed slice.
 func removeFromSlice(a []string, v string) []string {
 	for i, str := range a {
 		if str == v {

--- a/pkg/image/reference_test.go
+++ b/pkg/image/reference_test.go
@@ -16,7 +16,6 @@ package image
 
 import (
 	"fmt"
-	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -186,9 +185,7 @@ func TestMergeStrSlice(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			actual := mergeStrSlice(tc.s1, tc.s2)
-			sort.Strings(actual)
-			sort.Strings(tc.expect)
-			require.Equal(t, tc.expect, actual)
+			require.ElementsMatch(t, tc.expect, actual)
 		})
 	}
 }
@@ -226,4 +223,67 @@ func TestRemoveFromSlice(t *testing.T) {
 			require.Equal(t, tc.expect, actual)
 		})
 	}
+}
+
+func TestReferenceDigests(t *testing.T) {
+	ref := &Reference{
+		digests: []string{
+			"gcr.io/cri-tools/test-image@sha256:9179135b4b4cc5a8721e09379244807553c318d92fa3111a65133241551ca343",
+			"gcr.io/cri-tools/test-image@sha256:9327532a05078d7efd5a0ef9ace1ee5cd278653d8df53590e2fb7a4a34cb0bb8",
+		},
+	}
+
+	digests := ref.Digests()
+	digests = append(digests, "will-not-affect")
+	require.NotEqual(t, ref.Digests(), digests)
+	require.NotEqual(t, ref.digests, digests)
+
+	ref.AddDigests([]string{
+		"gcr.io/cri-tools/test-image@sha256:73a84b7ecd215008166111f3beb0a8da142535afafa68439e6292d173bc1251f",
+		"gcr.io/cri-tools/test-image@sha256:d50278eebfe4ca5655cc28503983f7c947914a34fbbb805481657d39e98f33f0",
+	})
+	require.ElementsMatch(t, []string{
+		"gcr.io/cri-tools/test-image@sha256:9179135b4b4cc5a8721e09379244807553c318d92fa3111a65133241551ca343",
+		"gcr.io/cri-tools/test-image@sha256:9327532a05078d7efd5a0ef9ace1ee5cd278653d8df53590e2fb7a4a34cb0bb8",
+		"gcr.io/cri-tools/test-image@sha256:73a84b7ecd215008166111f3beb0a8da142535afafa68439e6292d173bc1251f",
+		"gcr.io/cri-tools/test-image@sha256:d50278eebfe4ca5655cc28503983f7c947914a34fbbb805481657d39e98f33f0",
+	}, ref.Digests())
+
+	ref.RemoveDigest("gcr.io/cri-tools/test-image@sha256:9327532a05078d7efd5a0ef9ace1ee5cd278653d8df53590e2fb7a4a34cb0bb8")
+	require.ElementsMatch(t, []string{
+		"gcr.io/cri-tools/test-image@sha256:9179135b4b4cc5a8721e09379244807553c318d92fa3111a65133241551ca343",
+		"gcr.io/cri-tools/test-image@sha256:73a84b7ecd215008166111f3beb0a8da142535afafa68439e6292d173bc1251f",
+		"gcr.io/cri-tools/test-image@sha256:d50278eebfe4ca5655cc28503983f7c947914a34fbbb805481657d39e98f33f0",
+	}, ref.Digests())
+
+}
+
+func TestReferenceTags(t *testing.T) {
+	ref := &Reference{
+		tags: []string{
+			"gcr.io/cri-tools/test-image-tags:1",
+			"gcr.io/cri-tools/test-image-tags:2",
+		},
+	}
+
+	tags := ref.Tags()
+	tags = append(tags, "will-not-affect")
+	require.NotEqual(t, ref.Tags(), tags)
+	require.NotEqual(t, ref.tags, tags)
+
+	ref.AddTags([]string{"new-tag", "new-tag-2"})
+	require.ElementsMatch(t, []string{
+		"gcr.io/cri-tools/test-image-tags:1",
+		"gcr.io/cri-tools/test-image-tags:2",
+		"new-tag",
+		"new-tag-2",
+	}, ref.Tags())
+
+	ref.RemoveTag("gcr.io/cri-tools/test-image-tags:2")
+	require.ElementsMatch(t, []string{
+		"gcr.io/cri-tools/test-image-tags:1",
+		"new-tag",
+		"new-tag-2",
+	}, ref.Tags())
+
 }

--- a/pkg/index/image.go
+++ b/pkg/index/image.go
@@ -58,6 +58,43 @@ func (i *ImageIndex) Find(id string) (*image.Info, error) {
 	return info, err
 }
 
+// Add adds the given image info to the index.
+// If image with the same ID already exists it updates old image info appropriately.
+func (i *ImageIndex) Add(image *image.Info) error {
+	oldImage, err := i.Find(image.ID())
+	if err != nil && err != ErrImageNotFound {
+		return fmt.Errorf("could not find old image: %v", err)
+	}
+	if err == ErrImageNotFound {
+		return i.add(image)
+	}
+	return i.merge(oldImage, image)
+}
+
+// Remove removes pod from index if it present or returns otherwise.
+func (i *ImageIndex) Remove(id string) error {
+	imgInfo, err := i.Find(id)
+	if err != nil {
+		return err
+	}
+	err = i.indx.Delete(imgInfo.ID())
+	if err != nil {
+		return fmt.Errorf("could not remove image: %v", err)
+	}
+
+	i.removeRefs(imgInfo.Ref().Tags()...)
+	i.removeRefs(imgInfo.Ref().Digests()...)
+	return nil
+}
+
+// Iterate calls handler func on each pod registered in index.
+func (i *ImageIndex) Iterate(handler func(image *image.Info)) {
+	innerIterate := func(key string, item interface{}) {
+		handler(item.(*image.Info))
+	}
+	i.indx.Iterate(innerIterate)
+}
+
 func (i *ImageIndex) find(id string) (*image.Info, error) {
 	item, err := i.indx.Get(id)
 	if err == truncindex.ErrNotFound {
@@ -70,36 +107,10 @@ func (i *ImageIndex) find(id string) (*image.Info, error) {
 	return info, nil
 }
 
-// Remove removes pod from index if it present or returns otherwise.
-func (i *ImageIndex) Remove(id string) error {
-	imgInfo, err := i.Find(id)
-	if err != nil {
-		return err
-	}
-	err = i.indx.Delete(imgInfo.ID())
-	if err != nil {
-		return fmt.Errorf("could not remove imgInfo: %v", err)
-	}
-
-	i.removeRefs(imgInfo.Ref().Tags()...)
-	i.removeRefs(imgInfo.Ref().Digests()...)
-	return nil
-}
-
-// Add adds the given expectImage info. If expectImage already exists it
-// updates old info appropriately.
-func (i *ImageIndex) Add(image *image.Info) error {
-	oldImage, err := i.Find(image.ID())
-	if err != nil && err != ErrImageNotFound {
-		return fmt.Errorf("could not find old image: %v", err)
-	}
-	if err == ErrImageNotFound {
-		return i.add(image)
-	}
-	return i.merge(oldImage, image)
-}
-
 func (i *ImageIndex) add(image *image.Info) error {
+	if err := i.removeOverlapRefs(image); err != nil {
+		return nil
+	}
 	err := i.indx.Add(image.ID(), image)
 	if err != nil {
 		return fmt.Errorf("could not add image: %v", err)
@@ -119,31 +130,45 @@ func (i *ImageIndex) merge(oldImage, image *image.Info) error {
 
 	for _, tag := range image.Ref().Tags() {
 		oldID := i.readRef(tag)
-		if oldID == image.ID() {
-			continue
-		}
-		oldInfo, _ := i.Find(image.ID())
-		oldInfo.Ref().RemoveTag(tag)
 		i.setRef(tag, image.ID())
+		if oldID != "" && oldID != image.ID() {
+			oldInfo, _ := i.Find(image.ID())
+			oldInfo.Ref().RemoveTag(tag)
+		}
 	}
 	for _, digest := range image.Ref().Digests() {
 		oldID := i.readRef(digest)
-		if oldID == image.ID() {
-			continue
-		}
-		oldInfo, _ := i.Find(image.ID())
-		oldInfo.Ref().RemoveDigest(digest)
 		i.setRef(digest, image.ID())
+		if oldID != "" && oldID == image.ID() {
+			oldInfo, _ := i.Find(image.ID())
+			oldInfo.Ref().RemoveDigest(digest)
+		}
 	}
 	return nil
 }
 
-// Iterate calls handler func on each pod registered in index.
-func (i *ImageIndex) Iterate(handler func(image *image.Info)) {
-	innerIterate := func(key string, item interface{}) {
-		handler(item.(*image.Info))
+func (i *ImageIndex) removeOverlapRefs(image *image.Info) error {
+	for _, tag := range image.Ref().Tags() {
+		oldID := i.readRef(tag)
+		if oldID != "" {
+			oldImg, err := i.find(oldID)
+			if err != nil {
+				return err
+			}
+			oldImg.Ref().RemoveTag(tag)
+		}
 	}
-	i.indx.Iterate(innerIterate)
+	for _, digest := range image.Ref().Digests() {
+		oldID := i.readRef(digest)
+		if oldID != "" {
+			oldImg, err := i.find(oldID)
+			if err != nil {
+				return err
+			}
+			oldImg.Ref().RemoveDigest(digest)
+		}
+	}
+	return nil
 }
 
 func (i *ImageIndex) readRef(ref string) string {

--- a/pkg/index/image.go
+++ b/pkg/index/image.go
@@ -38,7 +38,7 @@ var (
 // NewImageIndex returns new ImageIndex ready to use.
 func NewImageIndex() *ImageIndex {
 	return &ImageIndex{
-		indx:    truncindex.NewTruncIndex(image.ImageIDLen),
+		indx:    truncindex.NewTruncIndex(image.IDLen),
 		refToID: make(map[string]string),
 	}
 }

--- a/pkg/index/image_test.go
+++ b/pkg/index/image_test.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2018 Sylabs, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/sylabs/cri/pkg/image"
+)
+
+func TestImageIndex(t *testing.T) {
+	t.Run("smoke test", SmokeTestImageIndex)
+	t.Run("advanced test", AdvancedTestImageIndex)
+}
+
+func SmokeTestImageIndex(t *testing.T) {
+	indx := NewImageIndex()
+
+	img1 := new(image.Info)
+	img1.SetID("busybox")
+	ref, err := image.ParseRef("library://library/default/busybox:1.29")
+	require.NoError(t, err, "could not parse busybox ref")
+	img1.SetRef(ref)
+
+	img2 := new(image.Info)
+	img2.SetID("nginx")
+	ref, err = image.ParseRef("nginx@sha256:31b8e90a349d1fce7621f5a5a08e4fc519b634f7d3feb09d53fac9b12aa4d991")
+	require.NoError(t, err, "could not parse nginx ref")
+	img2.SetRef(ref)
+
+	img3 := new(image.Info)
+	img3.SetID("alpine")
+	ref, err = image.ParseRef("library://library/default/alpine:3.8")
+	require.NoError(t, err, "could not parse alpine ref")
+	img3.SetRef(ref)
+
+	img4 := new(image.Info)
+	img4.SetID("alpine2")
+	ref, err = image.ParseRef("library://library/default/alpine")
+	require.NoError(t, err, "could not parse alpine ref")
+	img4.SetRef(ref)
+
+	t.Run("search empty index", func(t *testing.T) {
+		found, err := indx.Find(img1.ID())
+		require.Equal(t, ErrImageNotFound, err, "empty index didn't return ErrImageNotFound")
+		require.Nil(t, found, "empty index returned image")
+	})
+
+	t.Run("add to empty index", func(t *testing.T) {
+		err := indx.Add(img1)
+		require.NoError(t, err)
+		err = indx.Add(img2)
+		require.NoError(t, err)
+		err = indx.Add(img3)
+		require.NoError(t, err)
+	})
+
+	t.Run("search non-empty index", func(t *testing.T) {
+		found, err := indx.Find(img1.ID())
+		require.NoError(t, err, "index returned unexpected error")
+		require.Equal(t, found.ID(), img1.ID(), "index returned wrong image")
+		require.ElementsMatch(t, found.Ref().Tags(), img1.Ref().Tags(), "index returned wrong image")
+		require.ElementsMatch(t, found.Ref().Digests(), img1.Ref().Digests(), "index returned wrong image")
+
+		found, err = indx.Find(img2.ID())
+		require.NoError(t, err, "index returned unexpected error")
+		require.Equal(t, found.ID(), img2.ID(), "index returned wrong image")
+		require.ElementsMatch(t, found.Ref().Tags(), img2.Ref().Tags(), "index returned wrong image")
+		require.ElementsMatch(t, found.Ref().Digests(), img2.Ref().Digests(), "index returned wrong image")
+
+		found, err = indx.Find(img3.ID())
+		require.NoError(t, err, "index returned unexpected error")
+		require.Equal(t, found.ID(), img3.ID(), "index returned wrong image")
+		require.ElementsMatch(t, found.Ref().Tags(), img3.Ref().Tags(), "index returned wrong image")
+		require.ElementsMatch(t, found.Ref().Digests(), img3.Ref().Digests(), "index returned wrong image")
+
+		found, err = indx.Find("nonExistentID")
+		require.Equal(t, ErrImageNotFound, err, "empty index didn't return ErrImageNotFound")
+		require.Nil(t, found, "empty index returned image")
+	})
+
+	t.Run("remove from index", func(t *testing.T) {
+		err := indx.Remove(img2.Ref().Digests()[0])
+		require.NoError(t, err, "could not remove image from index")
+
+		found, err := indx.Find(img2.ID())
+		require.Equal(t, ErrImageNotFound, err, "empty index didn't return ErrImageNotFound")
+		require.Nil(t, found, "index returned unexpected image")
+	})
+
+	t.Run("ambiguous images", func(t *testing.T) {
+		err := indx.Add(img4)
+		require.NoError(t, err)
+
+		found, err := indx.Find(img3.ID())
+		require.Errorf(t, err, "index didn't error on ambiguous image id")
+		require.Nil(t, found, "index returned wrong image")
+
+		err = indx.Remove(img4.Ref().Tags()[0])
+		require.NoError(t, err, "could not remove ambiguous image from index")
+
+		found, err = indx.Find(img3.ID())
+		require.NoError(t, err, "index returned unexpected error")
+		require.Equal(t, found.ID(), img3.ID(), "index returned wrong image")
+		require.ElementsMatch(t, found.Ref().Tags(), img3.Ref().Tags(), "index returned wrong image")
+		require.ElementsMatch(t, found.Ref().Digests(), img3.Ref().Digests(), "index returned wrong image")
+	})
+
+}
+
+func AdvancedTestImageIndex(t *testing.T) {
+	indx := NewImageIndex()
+
+	img1 := new(image.Info)
+	img1.SetID("busybox")
+	ref, err := image.ParseRef("library://library/default/busybox:1.29")
+	require.NoError(t, err, "could not parse busybox ref")
+	img1.SetRef(ref)
+
+	img2 := new(image.Info)
+	img2.SetID("busybox")
+	ref, err = image.ParseRef("library://library/default/busybox:1.29")
+	require.NoError(t, err, "could not parse busybox ref")
+	ref.AddTags([]string{"library://library/default/busybox:latest"})
+	ref.AddDigests([]string{"library://library/default/busybox:sha256.165768770ca428e9e6d8290d5672652773edf1f80d442252a0ec737ed2cc312c"})
+	img2.SetRef(ref)
+
+	img3 := new(image.Info)
+	img3.SetID("busyboxNew")
+	ref, err = image.ParseRef("library://library/default/busybox:latest")
+	require.NoError(t, err, "could not parse busybox ref")
+	img3.SetRef(ref)
+
+	err = indx.Add(img1)
+	require.NoError(t, err)
+
+	t.Run("merge images", func(t *testing.T) {
+		err := indx.Add(img2)
+		require.NoError(t, err)
+
+		found, err := indx.Find(img1.ID())
+		require.NoError(t, err, "index returned unexpected error")
+		require.Equal(t, found.ID(), img2.ID(), "index returned wrong image")
+		require.ElementsMatch(t, found.Ref().Tags(), img2.Ref().Tags(), "index returned wrong image")
+		require.ElementsMatch(t, found.Ref().Digests(), img2.Ref().Digests(), "index returned wrong image")
+	})
+
+	t.Run("add overlapping image", func(t *testing.T) {
+		err := indx.Add(img3)
+		require.NoError(t, err)
+
+		var count int
+		indx.Iterate(func(image *image.Info) {
+			count++
+
+			if image.ID() == img2.ID() {
+				require.ElementsMatch(t, image.Ref().Tags(), img1.Ref().Tags(), "index returned wrong old image tags")
+				require.ElementsMatch(t, image.Ref().Digests(), img2.Ref().Digests(), "index returned wrong old image digests")
+			}
+			if image.ID() == img3.ID() {
+				require.ElementsMatch(t, image.Ref().Tags(), img3.Ref().Tags(), "index returned wrong new image tags")
+				require.ElementsMatch(t, image.Ref().Digests(), img3.Ref().Digests(), "index returned wrong new image digests")
+			}
+		})
+		require.Equal(t, 2, count)
+	})
+}


### PR DESCRIPTION
This PR fixes #81 (bug in image index implementation which led to invalid image tags when listing). 

Tests where added to make sure image index and image info work correctly.