### PR TITLE
Implement exec sync in container

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains Singularity implementation of [Kubernetes CRI](https://
 two separate services: runtime and image, each of which implements K8s RuntimeService and ImageService respectively.
 
 
-The CRI is currently under development and passes 23/71 [validation tests](https://github.com/kubernetes-sigs/cri-tools/blob/master/docs/validation.md).
+The CRI is currently under development and passes 40/71 [validation tests](https://github.com/kubernetes-sigs/cri-tools/blob/master/docs/validation.md).
 
 ## Quick Start
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -98,6 +98,9 @@ func main() {
 
 	<-exitCh
 
-	grpcServer.Stop()
 	log.Println("Singularity CRI service exiting...")
+	if err := syRuntime.Shutdown(); err != nil {
+		log.Printf("error during singularity runtime service shutdown: %v", err)
+	}
+	grpcServer.Stop()
 }

--- a/examples/info-cont.json
+++ b/examples/info-cont.json
@@ -6,6 +6,7 @@
   "image": {
     "image": "library://sashayakovtseva/test/test-info"
   },
+  "command": ["./test"],
   "envs": [
     {
       "key": "MY_CUSTOM_VAR",

--- a/examples/info-stream.json
+++ b/examples/info-stream.json
@@ -6,6 +6,7 @@
   "image": {
     "image": "library://sashayakovtseva/test/test-info:stream"
   },
+  "command": ["./test"],
   "envs": [
     {
       "key": "MY_CUSTOM_VAR",

--- a/examples/interactive.json
+++ b/examples/interactive.json
@@ -6,6 +6,7 @@
   "image": {
     "image": "sashayakovtseva/test-info:interactive"
   },
+  "command": ["./test"],
   "log_path": "interactive/1.log",
   "stdin": true,
   "tty": true

--- a/pkg/kube/container_files.go
+++ b/pkg/kube/container_files.go
@@ -203,9 +203,11 @@ func (c *Container) cleanupFiles(silent bool) error {
 	if err != nil && !silent {
 		return fmt.Errorf("could not cleanup container: %v", err)
 	}
-	err = os.RemoveAll(filepath.Dir(c.logPath))
-	if err != nil && !silent {
-		return fmt.Errorf("could not remove logs: %v", err)
+	if c.logPath != "" {
+		err = os.RemoveAll(filepath.Dir(c.logPath))
+		if err != nil && !silent {
+			return fmt.Errorf("could not remove logs: %v", err)
+		}
 	}
 	return nil
 }

--- a/pkg/server/runtime/runtime.go
+++ b/pkg/server/runtime/runtime.go
@@ -80,6 +80,15 @@ func NewSingularityRuntime(streamURL string, imgIndex *index.ImageIndex) (*Singu
 	return runtime, nil
 }
 
+// Shutdown shuts down any running background tasks created by SingularityRuntime.
+// This methods should be called when SingularityRuntime will no longer be used.
+func (s *SingularityRuntime) Shutdown() error {
+	if err := s.streaming.Stop(); err != nil {
+		return fmt.Errorf("could not stop streaming server: %v", err)
+	}
+	return nil
+}
+
 // Version returns the runtime name, runtime version and runtime API version
 func (s *SingularityRuntime) Version(context.Context, *k8s.VersionRequest) (*k8s.VersionResponse, error) {
 	const kubeAPIVersion = "0.1.0"

--- a/pkg/singularity/runtime/client.go
+++ b/pkg/singularity/runtime/client.go
@@ -16,14 +16,13 @@ package runtime
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
-
-	"context"
 	"syscall"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -37,6 +36,7 @@ type (
 		baseCmd []string
 	}
 
+	// ExecResponse holds result of command execution inside a container.
 	ExecResponse struct {
 		// Captured command stdout output.
 		Stdout []byte

--- a/pkg/singularity/runtime/client.go
+++ b/pkg/singularity/runtime/client.go
@@ -23,10 +23,11 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sylabs/cri/pkg/singularity"
 	"context"
 	"syscall"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sylabs/cri/pkg/singularity"
 )
 
 type (
@@ -48,7 +49,7 @@ type (
 
 // NewCLIClient returns new CLIClient ready to use.
 func NewCLIClient() *CLIClient {
-	return &CLIClient{baseCmd: []string{singularity.RuntimeName, "-d", "oci"}}
+	return &CLIClient{baseCmd: []string{singularity.RuntimeName, "-s", "oci"}}
 }
 
 // State returns state of a container with passed id.

--- a/pkg/singularity/runtime/client.go
+++ b/pkg/singularity/runtime/client.go
@@ -25,13 +25,26 @@ import (
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sylabs/cri/pkg/singularity"
+	"context"
+	"syscall"
 )
 
-// CLIClient is a type for convenient interaction with
-// singularity OCI runtime engine via CLI.
-type CLIClient struct {
-	baseCmd []string
-}
+type (
+	// CLIClient is a type for convenient interaction with
+	// singularity OCI runtime engine via CLI.
+	CLIClient struct {
+		baseCmd []string
+	}
+
+	ExecResponse struct {
+		// Captured command stdout output.
+		Stdout []byte
+		// Captured command stderr output.
+		Stderr []byte
+		// Exit code the command finished with.
+		ExitCode int32
+	}
+)
 
 // NewCLIClient returns new CLIClient ready to use.
 func NewCLIClient() *CLIClient {
@@ -79,6 +92,40 @@ func (c *CLIClient) Create(id, bundle string, flags ...string) error {
 func (c *CLIClient) Start(id string) error {
 	cmd := append(c.baseCmd, "start", id)
 	return silentRun(cmd)
+}
+
+// Exec executes a command inside a container.
+func (c *CLIClient) Exec(ctx context.Context, id string, args ...string) (*ExecResponse, error) {
+	cmd := append(c.baseCmd, "exec")
+	cmd = append(cmd, id)
+	cmd = append(cmd, args...)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	runCmd := exec.CommandContext(ctx, cmd[0], cmd[1:]...)
+	runCmd.Stdout = &stdout
+	runCmd.Stderr = &stderr
+
+	log.Printf("executing %v", cmd)
+	err := runCmd.Run()
+	var exitCode int32
+	exitErr, ok := err.(*exec.ExitError)
+	if ok {
+		var waitStatus syscall.WaitStatus
+		waitStatus, ok = exitErr.Sys().(syscall.WaitStatus)
+		if ok {
+			exitCode = int32(waitStatus.ExitStatus())
+		}
+	}
+	if !ok && err != nil {
+		return nil, fmt.Errorf("could not execute: %v", err)
+	}
+	return &ExecResponse{
+		Stdout:   stdout.Bytes(),
+		Stderr:   stderr.Bytes(),
+		ExitCode: exitCode,
+	}, nil
 }
 
 // Kill asks runtime to send SIGINT to container with passed id.


### PR DESCRIPTION
Exec sync is simply calling OCI engine exec correctly. Since k8s may pass exec timeout, OCI engine CLI is called with CommandContext which accepts context with timeout set. 

Closes #85. 