### PR TITLE
Implement reopening container log file

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -265,7 +265,7 @@
 
 [[projects]]
   branch = "master-oci"
-  digest = "1:9bc7258f984867c16a633ccb049b9a49ba985bc33c3e64ede9d7c0b7da3f7cb6"
+  digest = "1:258bd6c08489cbdf8b6fa5b0b44901b6e283b1ef26abc00f2980ab0c9a8fea77"
   name = "github.com/sylabs/singularity"
   packages = [
     "internal/pkg/sylog",
@@ -280,7 +280,7 @@
     "pkg/util/user-agent",
   ]
   pruneopts = "UT"
-  revision = "66b4f095759858c1399975e9bace0262e375b531"
+  revision = "8293832a0ba49fad38ca7d296bf922fbc17e35d5"
   source = "github.com/cclerget/singularity"
 
 [[projects]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,29 +1,3 @@
-# Gopkg.toml example
-#
-# Refer to https://golang.github.io/dep/docs/Gopkg.toml.html
-# for detailed Gopkg.toml documentation.
-#
-# required = ["github.com/user/thing/cmd/thing"]
-# ignored = ["github.com/user/project/pkgX", "bitbucket.org/user/project/pkgA/pkgY"]
-#
-# [[constraint]]
-#   name = "github.com/user/project"
-#   version = "1.0.0"
-#
-# [[constraint]]
-#   name = "github.com/user/project2"
-#   branch = "dev"
-#   source = "github.com/myfork/project2"
-#
-# [[override]]
-#   name = "github.com/x/y"
-#   version = "2.4.0"
-#
-# [prune]
-#   non-go = false
-#   go-tests = true
-#   unused-packages = true
-
 [[constraint]]
   name = "k8s.io/kubernetes"
   version = "~1.11.4"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains Singularity implementation of [Kubernetes CRI](https://
 two separate services: runtime and image, each of which implements K8s RuntimeService and ImageService respectively.
 
 
-The CRI is currently under development and passes 40/71 [validation tests](https://github.com/kubernetes-sigs/cri-tools/blob/master/docs/validation.md).
+The CRI is currently under development and passes 38/71 [validation tests](https://github.com/kubernetes-sigs/cri-tools/blob/master/docs/validation.md).
 
 ## Quick Start
 

--- a/pkg/kube/container.go
+++ b/pkg/kube/container.go
@@ -16,6 +16,7 @@ package kube
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -27,6 +28,7 @@ import (
 	"github.com/sylabs/cri/pkg/rand"
 	"github.com/sylabs/cri/pkg/singularity/runtime"
 	"github.com/sylabs/singularity/pkg/ociruntime"
+	"github.com/sylabs/singularity/pkg/util/unix"
 	k8s "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 )
 
@@ -291,6 +293,30 @@ func (c *Container) Exec(cmd []string, stdin io.Reader, stdout, stderr io.WriteC
 func (c *Container) PrepareExec(cmd []string) *exec.Cmd {
 	ctx := context.Background()
 	return c.cli.PrepareExec(ctx, c.id, cmd...)
+}
+
+// ReopenLogFile reopens container log file.
+// This method is usually called when logs are rotated.
+func (c *Container) ReopenLogFile() error {
+	socket := c.ControlSocket()
+	if socket == "" {
+		return fmt.Errorf("container didn't provide control socket")
+
+	}
+	ctrlSock, err := unix.Dial(socket)
+	if err != nil {
+		return fmt.Errorf("could not conntect to control socket: %v", err)
+	}
+	defer ctrlSock.Close()
+
+	ctrl := ociruntime.Control{
+		ReopenLog: true,
+	}
+	err = json.NewEncoder(ctrlSock).Encode(&ctrl)
+	if err != nil {
+		return fmt.Errorf("could not send reopen log to control socket: %v", err)
+	}
+	return nil
 }
 
 // MatchesFilter tests Container against passed filter and returns true if it matches.

--- a/pkg/kube/container.go
+++ b/pkg/kube/container.go
@@ -305,7 +305,7 @@ func (c *Container) ReopenLogFile() error {
 	}
 	ctrlSock, err := unix.Dial(socket)
 	if err != nil {
-		return fmt.Errorf("could not conntect to control socket: %v", err)
+		return fmt.Errorf("could not connect to control socket: %v", err)
 	}
 	defer ctrlSock.Close()
 

--- a/pkg/kube/container_files.go
+++ b/pkg/kube/container_files.go
@@ -204,9 +204,13 @@ func (c *Container) cleanupFiles(silent bool) error {
 		return fmt.Errorf("could not cleanup container: %v", err)
 	}
 	if c.logPath != "" {
-		err = os.RemoveAll(filepath.Dir(c.logPath))
-		if err != nil && !silent {
-			return fmt.Errorf("could not remove logs: %v", err)
+		dir := filepath.Dir(c.logPath)
+		// in case container's logs are not stored separately
+		if dir != c.pod.GetLogDirectory() {
+			err = os.RemoveAll(dir)
+			if err != nil && !silent {
+				return fmt.Errorf("could not remove logs: %v", err)
+			}
 		}
 	}
 	return nil

--- a/pkg/server/runtime/runtime.go
+++ b/pkg/server/runtime/runtime.go
@@ -125,6 +125,9 @@ func (s *SingularityRuntime) ReopenContainerLog(ctx context.Context, req *k8s.Re
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
+	if cont.State() != k8s.ContainerState_CONTAINER_RUNNING {
+		return nil, status.Error(codes.InvalidArgument, "container is not running")
+	}
 
 	err = cont.ReopenLogFile()
 	if err != nil {

--- a/vendor/github.com/sylabs/singularity/pkg/sypgp/sypgp.go
+++ b/vendor/github.com/sylabs/singularity/pkg/sypgp/sypgp.go
@@ -639,7 +639,6 @@ func doPushRequest(w *bytes.Buffer, keyserverURI, authToken string) (*http.Reque
 		return nil, err
 	}
 	u.Path = "pks/add"
-	u.RawQuery = v.Encode()
 
 	r, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(v.Encode()))
 	if err != nil {


### PR DESCRIPTION
To reopen log file CRI simply asks OCI engine to do so by sending control object into a socket.
Additionally, extra check upon container files cleanup added, so logs of others are not removed if container logs are not stored in a separate directory.

Due to raw logging in OCI engine number of passed CRI validation tests decreased a bit (potentially it is 40+). 

Closes  #97 