### PR TITLE
Implement port forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ To work on Singularity CRI install the following:
 - [dep](https://golang.github.io/dep/docs/installation.html)
 - [gometalinter](https://github.com/alecthomas/gometalinter#installing)
 - build-essential/Development tools and libssl-dev uuid-dev squashfs-tools -- packages
+- socat package to perform port forwarding
 - singularity with OCI support from https://github.com/cclerget/singularity/tree/master-oci (note the _fork_ repository and the _master-oci_ branch)
 
 Make sure you configured [go workspace](https://golang.org/doc/code.html).

--- a/pkg/kube/container.go
+++ b/pkg/kube/container.go
@@ -95,7 +95,6 @@ func (c *Container) State() k8s.ContainerState {
 		return k8s.ContainerState_CONTAINER_EXITED
 	}
 	return k8s.ContainerState_CONTAINER_UNKNOWN
-
 }
 
 // CreatedAt returns pod creation time in Unix nano.

--- a/pkg/kube/container_runtime.go
+++ b/pkg/kube/container_runtime.go
@@ -61,6 +61,11 @@ func (c *Container) UpdateState() error {
 	return nil
 }
 
+// Pid returns pid of the container process in the host's PID namespace.
+func (c *Container) Pid() int {
+	return c.ociState.Pid
+}
+
 func (c *Container) expectState(expect runtime.State) error {
 	log.Printf("waiting for state %d...", expect)
 	c.runtimeState = <-c.syncChan

--- a/pkg/kube/pod_runtime.go
+++ b/pkg/kube/pod_runtime.go
@@ -78,6 +78,23 @@ func (p *Pod) spawnOCIPod() error {
 	return nil
 }
 
+// UpdateState updates container state according to information
+// received from the runtime.
+func (p *Pod) UpdateState() error {
+	var err error
+	p.ociState, err = p.cli.State(p.id)
+	if err != nil {
+		return fmt.Errorf("could not get pod state: %v", err)
+	}
+	p.runtimeState = runtime.StatusToState(p.ociState.Status)
+	return nil
+}
+
+// Pid returns pid of the pod process in the host's PID namespace.
+func (p *Pod) Pid() int {
+	return p.ociState.Pid
+}
+
 func (p *Pod) expectState(expect runtime.State) error {
 	log.Printf("waiting for state %d...", expect)
 	p.runtimeState = <-p.syncChan

--- a/pkg/server/runtime/container.go
+++ b/pkg/server/runtime/container.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"log"
 
+	"fmt"
+
 	"github.com/sylabs/cri/pkg/index"
 	"github.com/sylabs/cri/pkg/kube"
 	"google.golang.org/grpc/codes"
@@ -137,6 +139,13 @@ func (s *SingularityRuntime) ContainerStatus(_ context.Context, req *k8s.Contain
 	if err := cont.UpdateState(); err != nil {
 		return nil, status.Errorf(codes.Internal, "could not update container state: %v", err)
 	}
+
+	var verboseInfo map[string]string
+	if req.Verbose {
+		verboseInfo = map[string]string{
+			"pid": fmt.Sprintf("%d", cont.Pid()),
+		}
+	}
 	return &k8s.ContainerStatusResponse{
 		Status: &k8s.ContainerStatus{
 			Id:          cont.ID(),
@@ -155,6 +164,7 @@ func (s *SingularityRuntime) ContainerStatus(_ context.Context, req *k8s.Contain
 			Mounts:      cont.GetMounts(),
 			LogPath:     cont.LogPath(),
 		},
+		Info: verboseInfo,
 	}, nil
 }
 

--- a/pkg/server/runtime/container.go
+++ b/pkg/server/runtime/container.go
@@ -29,9 +29,8 @@ import (
 
 // CreateContainer creates a new container in specified PodSandbox.
 func (s *SingularityRuntime) CreateContainer(_ context.Context, req *k8s.CreateContainerRequest) (*k8s.CreateContainerResponse, error) {
-	if (req.GetConfig().GetTty() && !req.GetConfig().GetStdin()) ||
-		(req.GetConfig().GetStdin() && !req.GetConfig().GetTty()) {
-		return nil, status.Error(codes.InvalidArgument, "tty and stdin must be both either true or false")
+	if req.GetConfig().GetTty() && !req.GetConfig().GetStdin() {
+		return nil, status.Error(codes.InvalidArgument, "tty requires stdin to be true")
 	}
 
 	info, err := s.imageIndex.Find(req.Config.Image.Image)

--- a/pkg/server/runtime/runtime.go
+++ b/pkg/server/runtime/runtime.go
@@ -188,8 +188,12 @@ func (s *SingularityRuntime) Attach(ctx context.Context, req *k8s.AttachRequest)
 }
 
 // PortForward prepares a streaming endpoint to forward ports from a PodSandbox.
-func (s *SingularityRuntime) PortForward(context.Context, *k8s.PortForwardRequest) (*k8s.PortForwardResponse, error) {
-	return &k8s.PortForwardResponse{}, status.Errorf(codes.Unimplemented, "not implemented")
+func (s *SingularityRuntime) PortForward(ctx context.Context, req *k8s.PortForwardRequest) (*k8s.PortForwardResponse, error) {
+	_, err := s.pods.Find(req.PodSandboxId)
+	if err != nil {
+		return nil, status.Error(codes.NotFound, "pod is not found")
+	}
+	return s.streaming.GetPortForward(req)
 }
 
 // ContainerStats returns stats of the container. If the container does not

--- a/pkg/server/runtime/streaming.go
+++ b/pkg/server/runtime/streaming.go
@@ -180,7 +180,7 @@ func (s *streamingRuntime) Attach(containerID string,
 			errors <- err
 		}()
 	}
-	if tty && c.GetStdin() && stdin != nil {
+	if c.GetStdin() && stdin != nil {
 		go func() {
 			// copy until ctrl-d hits
 			_, err := utils.CopyDetachable(attachSock, stdin, []byte{4})


### PR DESCRIPTION
Port forwarding is implemented using `socat`.

Additionally, process pid is returned for pod and container on verbose status call.

Closes #99.
Closes #36.
Closes #78.