### PR TITLE
Validate sysctls for pod

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -280,7 +280,7 @@
     "pkg/util/user-agent",
   ]
   pruneopts = "UT"
-  revision = "8293832a0ba49fad38ca7d296bf922fbc17e35d5"
+  revision = "49e3612b7d8928d339d45e41b32bf7dfe2239bcb"
   source = "github.com/cclerget/singularity"
 
 [[projects]]

--- a/examples/nginx.json
+++ b/examples/nginx.json
@@ -6,6 +6,7 @@
   "image": {
     "image": "nginx"
   },
+  "log_path": "nginx.log",
   "linux": {
     "security_context": {
       "namespace_options": {}

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -104,6 +104,10 @@ func (p *Pod) Run() error {
 	}()
 
 	p.runOnce.Do(func() {
+		if err = p.validateConfig(); err != nil {
+			err = fmt.Errorf("invalid pod config: %v", err)
+			return
+		}
 		if err = p.prepareFiles(); err != nil {
 			err = fmt.Errorf("could not create pod directories: %v", err)
 			return

--- a/pkg/kube/pod_validate.go
+++ b/pkg/kube/pod_validate.go
@@ -22,7 +22,7 @@ func (p *Pod) validateConfig() error {
 	hasIPC := p.GetLinux().GetSecurityContext().GetNamespaceOptions().GetIpc() == k8s.NamespaceMode_POD
 	hasNET := p.GetLinux().GetSecurityContext().GetNamespaceOptions().GetNetwork() == k8s.NamespaceMode_POD
 
-	for sysctl, _ := range p.GetLinux().GetSysctls() {
+	for sysctl := range p.GetLinux().GetSysctls() {
 		for prefix, nsType := range sysctlToNs {
 			if strings.HasPrefix(sysctl, prefix) {
 				if (nsType == specs.IPCNamespace && !hasIPC) ||

--- a/pkg/kube/pod_validate.go
+++ b/pkg/kube/pod_validate.go
@@ -1,0 +1,37 @@
+package kube
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+	k8s "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
+)
+
+var (
+	sysctlToNs = map[string]specs.LinuxNamespaceType{
+		"kernel.shm": specs.IPCNamespace,
+		"kernel.msg": specs.IPCNamespace,
+		"kernel.sem": specs.IPCNamespace,
+		"fs.mqueue.": specs.IPCNamespace,
+		"net.":       specs.NetworkNamespace,
+	}
+)
+
+func (p *Pod) validateConfig() error {
+	hasIPC := p.GetLinux().GetSecurityContext().GetNamespaceOptions().GetIpc() == k8s.NamespaceMode_POD
+	hasNET := p.GetLinux().GetSecurityContext().GetNamespaceOptions().GetNetwork() == k8s.NamespaceMode_POD
+
+	for sysctl, _ := range p.GetLinux().GetSysctls() {
+		for prefix, nsType := range sysctlToNs {
+			if strings.HasPrefix(sysctl, prefix) {
+				if (nsType == specs.IPCNamespace && !hasIPC) ||
+					(nsType == specs.NetworkNamespace && !hasNET) {
+					return fmt.Errorf("sysctl %s requires a separate %s namespace", sysctl, nsType)
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/server/runtime/pod.go
+++ b/pkg/server/runtime/pod.go
@@ -152,7 +152,7 @@ func (s *SingularityRuntime) ListPodSandbox(_ context.Context, req *k8s.ListPodS
 func (s *SingularityRuntime) findPod(id string) (*kube.Pod, error) {
 	pod, err := s.pods.Find(id)
 	if err == index.ErrPodNotFound {
-		return nil, status.Errorf(codes.NotFound, "pod not found")
+		return nil, status.Errorf(codes.NotFound, "pod is not found")
 	}
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())

--- a/pkg/singularity/runtime/client.go
+++ b/pkg/singularity/runtime/client.go
@@ -190,7 +190,6 @@ func (c *CLIClient) Attach(id string) error {
 func run(cmd []string) error {
 	runCmd := exec.Command(cmd[0], cmd[1:]...)
 	runCmd.Stderr = os.Stderr
-	runCmd.Stdout = os.Stdout
 
 	log.Printf("executing %v", cmd)
 	err := runCmd.Run()


### PR DESCRIPTION
Some sysctls are _namespaced_ (see https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/#setting-sysctls-for-a-pod) and may be set for each pod separately. In this PR extra check for such sysctls added to make sure pod config doesn't affect a whole node.