### PR TITLE
Change the way image registries are distinguished

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,15 +121,15 @@ To test CRI in interactive mode we suggest the following workflow:
 	
 6. You can also run container that outputs some system info (good to smoke test CRI):
 	```bash
-	$ sudo crictl pull library://sashayakovtseva/test/test-info
+	$ sudo crictl pull cloud.sylabs.io/sashayakovtseva/test/test-info
 
 	# sudo crictl create <podID> nginx.json test-pod.json
 	$ sudo crictl create 0e0538d57a52d info-cont.json test-pod.json
 	bf040d311ca7d929ee20de4973df5c00aaf6f0e733feb695e985757686fb121b
 	
 	$ sudo crictl ps -a
-	CONTAINER ID        IMAGE                                      CREATED             STATE               NAME                ATTEMPT             POD ID
-	bf040d311ca7d       library://sashayakovtseva/test/test-info   10 seconds ago      Created             testcontainer       1                   0e0538d57a52d
+	CONTAINER ID        IMAGE                                    		  	CREATED             STATE               NAME                ATTEMPT             POD ID
+	bf040d311ca7d       cloud.sylabs.io/sashayakovtseva/test/test-info   	10 seconds ago      Created             testcontainer       1                   0e0538d57a52d
 
 	# sudo crictl start <containerID>
 	$ sudo crictl start bf040d311ca7d

--- a/examples/info-cont.json
+++ b/examples/info-cont.json
@@ -4,7 +4,7 @@
     "attempt": 1
   },
   "image": {
-    "image": "library://sashayakovtseva/test/test-info"
+    "image": "cloud.sylabs.io/sashayakovtseva/test/test-info"
   },
   "command": ["./test"],
   "envs": [

--- a/examples/info-stream.json
+++ b/examples/info-stream.json
@@ -4,7 +4,7 @@
     "attempt": 1
   },
   "image": {
-    "image": "library://sashayakovtseva/test/test-info:stream"
+    "image": "cloud.sylabs.io/sashayakovtseva/test/test-info:stream"
   },
   "command": ["./test"],
   "envs": [

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -31,7 +31,6 @@ import (
 	"github.com/sylabs/cri/pkg/singularity"
 	"github.com/sylabs/sif/pkg/sif"
 	library "github.com/sylabs/singularity/pkg/client/library"
-	shub "github.com/sylabs/singularity/pkg/client/shub"
 	"github.com/sylabs/singularity/pkg/signing"
 	k8s "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 )
@@ -141,9 +140,6 @@ func Pull(location string, ref *Reference) (img *Info, err error) {
 	switch ref.uri {
 	case singularity.LibraryDomain:
 		err = library.DownloadImage(pullPath, pullURL, singularity.LibraryURL, true, "")
-	case singularity.ShubDomain:
-		pullURL = "shub://" + pullURL
-		err = shub.DownloadImage(pullPath, pullURL, true, false)
 	case singularity.DockerDomain:
 		remote := fmt.Sprintf("%s://%s", singularity.DockerProtocol, pullURL)
 		var errMsg bytes.Buffer

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -74,26 +74,6 @@ func TestPullImage(t *testing.T) {
 			},
 			expectError: nil,
 		},
-		{
-			name: "shub image",
-			ref: &Reference{
-				uri:     singularity.ShubDomain,
-				tags:    []string{"singularity-hub.org/vsoch/hello-world"},
-				digests: nil,
-			},
-			expectImage: &Info{
-				id:     "4d398430ceded6a261a2304df3e75efe558892ba94eec25d2392991fe3a13dce",
-				sha256: "4d398430ceded6a261a2304df3e75efe558892ba94eec25d2392991fe3a13dce",
-				size:   65347615,
-				path:   filepath.Join(os.TempDir(), "4d398430ceded6a261a2304df3e75efe558892ba94eec25d2392991fe3a13dce"),
-				ref: &Reference{
-					uri:     "singularity-hub.org",
-					tags:    []string{"singularity-hub.org/vsoch/hello-world"},
-					digests: nil,
-				},
-			},
-			expectError: nil,
-		},
 	}
 
 	for _, tc := range tt {
@@ -103,7 +83,7 @@ func TestPullImage(t *testing.T) {
 			if image != nil {
 				require.NoError(t, image.Remove(), "could not remove image")
 			}
-			if tc.ref.uri == singularity.DockerProtocol {
+			if tc.ref.uri == singularity.DockerDomain {
 				image.id = ""
 				image.sha256 = ""
 				image.path = ""

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -15,7 +15,6 @@
 package image
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -38,7 +37,7 @@ func TestPullImage(t *testing.T) {
 		{
 			name: "docker image",
 			ref: &Reference{
-				uri:     "docker",
+				uri:     singularity.DockerDomain,
 				tags:    []string{"gcr.io/cri-tools/test-image-latest"},
 				digests: nil,
 			},
@@ -48,7 +47,7 @@ func TestPullImage(t *testing.T) {
 				size:   741376,
 				path:   "",
 				ref: &Reference{
-					uri:     "docker",
+					uri:     singularity.DockerDomain,
 					tags:    []string{"gcr.io/cri-tools/test-image-latest"},
 					digests: nil,
 				},
@@ -58,9 +57,9 @@ func TestPullImage(t *testing.T) {
 		{
 			name: "library image",
 			ref: &Reference{
-				uri:     "library",
+				uri:     singularity.LibraryDomain,
 				tags:    nil,
-				digests: []string{"library://sashayakovtseva/test/image-server:sha256.d50278eebfe4ca5655cc28503983f7c947914a34fbbb805481657d39e98f33f0"},
+				digests: []string{"cloud.sylabs.io/sashayakovtseva/test/image-server:sha256.d50278eebfe4ca5655cc28503983f7c947914a34fbbb805481657d39e98f33f0"},
 			},
 			expectImage: &Info{
 				id:     "d50278eebfe4ca5655cc28503983f7c947914a34fbbb805481657d39e98f33f0",
@@ -68,9 +67,9 @@ func TestPullImage(t *testing.T) {
 				size:   5521408,
 				path:   filepath.Join(os.TempDir(), "d50278eebfe4ca5655cc28503983f7c947914a34fbbb805481657d39e98f33f0"),
 				ref: &Reference{
-					uri:     "library",
+					uri:     singularity.LibraryDomain,
 					tags:    nil,
-					digests: []string{"library://sashayakovtseva/test/image-server:sha256.d50278eebfe4ca5655cc28503983f7c947914a34fbbb805481657d39e98f33f0"},
+					digests: []string{"cloud.sylabs.io/sashayakovtseva/test/image-server:sha256.d50278eebfe4ca5655cc28503983f7c947914a34fbbb805481657d39e98f33f0"},
 				},
 			},
 			expectError: nil,
@@ -78,8 +77,8 @@ func TestPullImage(t *testing.T) {
 		{
 			name: "shub image",
 			ref: &Reference{
-				uri:     "shub",
-				tags:    []string{"shub://vsoch/hello-world"},
+				uri:     singularity.ShubDomain,
+				tags:    []string{"singularity-hub.org/vsoch/hello-world"},
 				digests: nil,
 			},
 			expectImage: &Info{
@@ -88,22 +87,12 @@ func TestPullImage(t *testing.T) {
 				size:   65347615,
 				path:   filepath.Join(os.TempDir(), "4d398430ceded6a261a2304df3e75efe558892ba94eec25d2392991fe3a13dce"),
 				ref: &Reference{
-					uri:     "shub",
-					tags:    []string{"shub://vsoch/hello-world"},
+					uri:     "singularity-hub.org",
+					tags:    []string{"singularity-hub.org/vsoch/hello-world"},
 					digests: nil,
 				},
 			},
 			expectError: nil,
-		},
-		{
-			name: "unknown image",
-			ref: &Reference{
-				uri:     "rkt",
-				tags:    []string{"rkt://vsoch/hello-world"},
-				digests: nil,
-			},
-			expectImage: nil,
-			expectError: fmt.Errorf("could not pull image: unknown image registry: rkt"),
 		},
 	}
 
@@ -238,7 +227,7 @@ func TestInfo_UnmarshalJSON(t *testing.T) {
 "sha256":"0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
 "size":741376,
 "path":"/var/lib/singularity/0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
-"ref":{"uri":"docker","tags":["busybox:1.28"],"digests":null}}`
+"ref":{"uri":"docker.io","tags":["busybox:1.28"],"digests":null}}`
 
 	info := new(Info)
 	err := info.UnmarshalJSON([]byte(input))
@@ -249,14 +238,14 @@ func TestInfo_UnmarshalJSON(t *testing.T) {
 		size:   741376,
 		path:   "/var/lib/singularity/0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
 		ref: &Reference{
-			uri:  "docker",
+			uri:  singularity.DockerDomain,
 			tags: []string{"busybox:1.28"},
 		},
 	}, info)
 }
 
 func TestInfo_MarshalJSON(t *testing.T) {
-	expect := []byte(`{"id":"0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0","sha256":"0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0","size":741376,"path":"/var/lib/singularity/0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0","ref":{"uri":"docker","tags":["busybox:1.28"],"digests":null}}`)
+	expect := []byte(`{"id":"0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0","sha256":"0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0","size":741376,"path":"/var/lib/singularity/0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0","ref":{"uri":"docker.io","tags":["busybox:1.28"],"digests":null}}`)
 
 	info := &Info{
 		id:     "0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
@@ -264,7 +253,7 @@ func TestInfo_MarshalJSON(t *testing.T) {
 		size:   741376,
 		path:   "/var/lib/singularity/0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
 		ref: &Reference{
-			uri:  "docker",
+			uri:  singularity.DockerDomain,
 			tags: []string{"busybox:1.28"},
 		},
 	}

--- a/pkg/image/reference.go
+++ b/pkg/image/reference.go
@@ -70,9 +70,6 @@ func ParseRef(imgRef string) (*Reference, error) {
 		case singularity.LibraryDomain:
 			uri = singularity.LibraryDomain
 			image = image[indx+1:]
-		case singularity.ShubDomain:
-			uri = singularity.ShubDomain
-			image = image[indx+1:]
 		case singularity.DockerDomain:
 			image = image[indx+1:]
 		}
@@ -83,8 +80,6 @@ func ParseRef(imgRef string) (*Reference, error) {
 	}
 
 	switch uri {
-	case singularity.ShubDomain:
-		fallthrough
 	case singularity.LibraryDomain:
 		if strings.Contains(image, "sha256.") {
 			ref.digests = append(ref.digests, imgRef)

--- a/pkg/image/reference.go
+++ b/pkg/image/reference.go
@@ -62,12 +62,20 @@ func (r *Reference) UnmarshalJSON(data []byte) error {
 
 // ParseRef constructs image reference based on imgRef.
 func ParseRef(imgRef string) (*Reference, error) {
-	uri := singularity.DockerProtocol
+	uri := singularity.DockerDomain
 	image := imgRef
-	indx := strings.Index(imgRef, "://")
+	indx := strings.IndexByte(imgRef, '/')
 	if indx != -1 {
-		uri = image[:indx]
-		image = image[indx+3:]
+		switch image[:indx] {
+		case singularity.LibraryDomain:
+			uri = singularity.LibraryDomain
+			image = image[indx+1:]
+		case singularity.ShubDomain:
+			uri = singularity.ShubDomain
+			image = image[indx+1:]
+		case singularity.DockerDomain:
+			image = image[indx+1:]
+		}
 	}
 
 	ref := Reference{
@@ -75,15 +83,15 @@ func ParseRef(imgRef string) (*Reference, error) {
 	}
 
 	switch uri {
-	case singularity.ShubProtocol:
+	case singularity.ShubDomain:
 		fallthrough
-	case singularity.LibraryProtocol:
+	case singularity.LibraryDomain:
 		if strings.Contains(image, "sha256.") {
 			ref.digests = append(ref.digests, imgRef)
 		} else {
 			ref.tags = append(ref.tags, NormalizedImageRef(imgRef))
 		}
-	case singularity.DockerProtocol:
+	case singularity.DockerDomain:
 		if strings.IndexByte(image, '@') != -1 {
 			ref.digests = append(ref.digests, image)
 		} else {
@@ -146,12 +154,7 @@ func (r *Reference) RemoveTag(tag string) {
 // NormalizedImageRef appends tag 'latest' if the passed ref
 // does not have any tag or digest already.
 func NormalizedImageRef(imgRef string) string {
-	image := imgRef
-	indx := strings.Index(imgRef, "://")
-	if indx != -1 {
-		image = imgRef[indx+3:]
-	}
-	i := strings.LastIndexByte(image, ':')
+	i := strings.LastIndexByte(imgRef, ':')
 	if i == -1 {
 		return imgRef + ":latest"
 	}

--- a/pkg/image/reference_test.go
+++ b/pkg/image/reference_test.go
@@ -15,10 +15,10 @@
 package image
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/sylabs/cri/pkg/singularity"
 )
 
 func TestParseImageRef(t *testing.T) {
@@ -29,47 +29,41 @@ func TestParseImageRef(t *testing.T) {
 		expectError error
 	}{
 		{
-			name:        "invalid uri",
-			ref:         "rkt://library/ubuntu:16.4",
-			expect:      nil,
-			expectError: fmt.Errorf("unknown image registry: rkt"),
-		},
-		{
 			name: "library with tag",
-			ref:  "library://sashayakovtseva/test/image-server:1",
+			ref:  "cloud.sylabs.io/sashayakovtseva/test/image-server:1",
 			expect: &Reference{
-				uri:     "library",
-				tags:    []string{"library://sashayakovtseva/test/image-server:1"},
+				uri:     singularity.LibraryDomain,
+				tags:    []string{"cloud.sylabs.io/sashayakovtseva/test/image-server:1"},
 				digests: nil,
 			},
 			expectError: nil,
 		},
 		{
 			name: "library without tag",
-			ref:  "library://sashayakovtseva/test/image-server",
+			ref:  "cloud.sylabs.io/sashayakovtseva/test/image-server",
 			expect: &Reference{
-				uri:     "library",
-				tags:    []string{"library://sashayakovtseva/test/image-server:latest"},
+				uri:     singularity.LibraryDomain,
+				tags:    []string{"cloud.sylabs.io/sashayakovtseva/test/image-server:latest"},
 				digests: nil,
 			},
 			expectError: nil,
 		},
 		{
 			name: "library with digest",
-			ref:  "library://sashayakovtseva/test/image-server:sha256.9327532a05078d7efd5a0ef9ace1ee5cd278653d8df53590e2fb7a4a34cb0bb8",
+			ref:  "cloud.sylabs.io/sashayakovtseva/test/image-server:sha256.9327532a05078d7efd5a0ef9ace1ee5cd278653d8df53590e2fb7a4a34cb0bb8",
 			expect: &Reference{
-				uri:     "library",
+				uri:     singularity.LibraryDomain,
 				tags:    nil,
-				digests: []string{"library://sashayakovtseva/test/image-server:sha256.9327532a05078d7efd5a0ef9ace1ee5cd278653d8df53590e2fb7a4a34cb0bb8"},
+				digests: []string{"cloud.sylabs.io/sashayakovtseva/test/image-server:sha256.9327532a05078d7efd5a0ef9ace1ee5cd278653d8df53590e2fb7a4a34cb0bb8"},
 			},
 			expectError: nil,
 		},
 		{
 			name: "shub without tag",
-			ref:  "shub://vsoch/singularity-hello-world",
+			ref:  "singularity-hub.org/vsoch/singularity-hello-world",
 			expect: &Reference{
-				uri:     "shub",
-				tags:    []string{"shub://vsoch/singularity-hello-world:latest"},
+				uri:     singularity.ShubDomain,
+				tags:    []string{"singularity-hub.org/vsoch/singularity-hello-world:latest"},
 				digests: nil,
 			},
 			expectError: nil,
@@ -78,7 +72,7 @@ func TestParseImageRef(t *testing.T) {
 			name: "docker without tag",
 			ref:  "gcr.io/cri-tools/test-image-tags",
 			expect: &Reference{
-				uri:     "docker",
+				uri:     singularity.DockerDomain,
 				tags:    []string{"gcr.io/cri-tools/test-image-tags:latest"},
 				digests: nil,
 			},
@@ -86,9 +80,9 @@ func TestParseImageRef(t *testing.T) {
 		},
 		{
 			name: "docker with tag",
-			ref:  "docker://gcr.io/cri-tools/test-image-tags:1",
+			ref:  "docker.io/gcr.io/cri-tools/test-image-tags:1",
 			expect: &Reference{
-				uri:     "docker",
+				uri:     singularity.DockerDomain,
 				tags:    []string{"gcr.io/cri-tools/test-image-tags:1"},
 				digests: nil,
 			},
@@ -96,9 +90,9 @@ func TestParseImageRef(t *testing.T) {
 		},
 		{
 			name: "docker with digest",
-			ref:  "docker://gcr.io/cri-tools/test-image-digest@sha256:9179135b4b4cc5a8721e09379244807553c318d92fa3111a65133241551ca343",
+			ref:  "docker.io/gcr.io/cri-tools/test-image-digest@sha256:9179135b4b4cc5a8721e09379244807553c318d92fa3111a65133241551ca343",
 			expect: &Reference{
-				uri:     "docker",
+				uri:     singularity.DockerDomain,
 				tags:    nil,
 				digests: []string{"gcr.io/cri-tools/test-image-digest@sha256:9179135b4b4cc5a8721e09379244807553c318d92fa3111a65133241551ca343"},
 			},
@@ -137,19 +131,19 @@ func TestNormalizedImageRef(t *testing.T) {
 			expect: "gcr.io/cri-tools/test-image-digest@sha256:9179135b4b4cc5a8721e09379244807553c318d92fa3111a65133241551ca343",
 		},
 		{
-			name:   "docker image with tag",
-			ref:    "library://sashayakovtseva/test/image-server:latest",
-			expect: "library://sashayakovtseva/test/image-server:latest",
+			name:   "library image with tag",
+			ref:    "cloud.sylabs.io/sashayakovtseva/test/image-server:latest",
+			expect: "cloud.sylabs.io/sashayakovtseva/test/image-server:latest",
 		},
 		{
 			name:   "library image without tag",
-			ref:    "library://sashayakovtseva/test/image-server",
-			expect: "library://sashayakovtseva/test/image-server:latest",
+			ref:    "cloud.sylabs.io/sashayakovtseva/test/image-server",
+			expect: "cloud.sylabs.io/sashayakovtseva/test/image-server:latest",
 		},
 		{
 			name:   "library image with digest",
-			ref:    "library://sashayakovtseva/test/image-server:sha256.9327532a05078d7efd5a0ef9ace1ee5cd278653d8df53590e2fb7a4a34cb0bb8",
-			expect: "library://sashayakovtseva/test/image-server:sha256.9327532a05078d7efd5a0ef9ace1ee5cd278653d8df53590e2fb7a4a34cb0bb8",
+			ref:    "cloud.sylabs.io/sashayakovtseva/test/image-server:sha256.9327532a05078d7efd5a0ef9ace1ee5cd278653d8df53590e2fb7a4a34cb0bb8",
+			expect: "cloud.sylabs.io/sashayakovtseva/test/image-server:sha256.9327532a05078d7efd5a0ef9ace1ee5cd278653d8df53590e2fb7a4a34cb0bb8",
 		},
 	}
 

--- a/pkg/image/reference_test.go
+++ b/pkg/image/reference_test.go
@@ -59,16 +59,6 @@ func TestParseImageRef(t *testing.T) {
 			expectError: nil,
 		},
 		{
-			name: "shub without tag",
-			ref:  "singularity-hub.org/vsoch/singularity-hello-world",
-			expect: &Reference{
-				uri:     singularity.ShubDomain,
-				tags:    []string{"singularity-hub.org/vsoch/singularity-hello-world:latest"},
-				digests: nil,
-			},
-			expectError: nil,
-		},
-		{
 			name: "docker without tag",
 			ref:  "gcr.io/cri-tools/test-image-tags",
 			expect: &Reference{

--- a/pkg/singularity/singularity.go
+++ b/pkg/singularity/singularity.go
@@ -24,19 +24,12 @@ const (
 	// LibraryURL is a default singularity library server address.
 	LibraryURL = "https://library.sylabs.io"
 
-	// LibraryProtocol holds the sylabs cloud library base URI.
+	// LibraryDomain holds the sylabs cloud library primary domain.
 	// For more info refer to https://cloud.sylabs.io/library.
-	LibraryProtocol = "library"
-
 	LibraryDomain = "cloud.sylabs.io"
 
+	// DockerDomain holds docker primary domain to pull images from.
 	DockerDomain = "docker.io"
-
-	ShubDomain = "singularity-hub.org"
-
-	// ShubProtocol holds singularity hub base URI.
-	// For more info refer to https://singularity-hub.org.
-	ShubProtocol = "shub"
 
 	// DockerProtocol holds docker hub base URI.
 	DockerProtocol = "docker"

--- a/pkg/singularity/singularity.go
+++ b/pkg/singularity/singularity.go
@@ -28,6 +28,12 @@ const (
 	// For more info refer to https://cloud.sylabs.io/library.
 	LibraryProtocol = "library"
 
+	LibraryDomain = "cloud.sylabs.io"
+
+	DockerDomain = "docker.io"
+
+	ShubDomain = "singularity-hub.org"
+
 	// ShubProtocol holds singularity hub base URI.
 	// For more info refer to https://singularity-hub.org.
 	ShubProtocol = "shub"


### PR DESCRIPTION
This PR changes the way images are referenced in order to align with the way kubelet parses image references. So `docker://` is substituted with `docker.io` and `library://` with `cloud.sylabs.io`.
Also shub support is removed.