### PR TITLE
Implement image filesystem usage scanning

### DIFF
--- a/pkg/server/image/image.go
+++ b/pkg/server/image/image.go
@@ -15,6 +15,7 @@
 package image
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -23,7 +24,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/sylabs/cri/pkg/image"
 	"github.com/sylabs/cri/pkg/index"
@@ -165,7 +168,54 @@ func (s *SingularityRegistry) ListImages(ctx context.Context, req *k8s.ListImage
 
 // ImageFsInfo returns information of the filesystem that is used to store images.
 func (s *SingularityRegistry) ImageFsInfo(context.Context, *k8s.ImageFsInfoRequest) (*k8s.ImageFsInfoResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "")
+	mount, err := mountPoint(s.storage)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "could not get storage mount point: %v", err)
+	}
+
+	storeDir, err := os.Open(s.storage)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "could not open image storage: %v", err)
+	}
+	defer storeDir.Close()
+
+	fi, err := storeDir.Stat()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "could not get storage info: %v", err)
+	}
+
+	fii, err := storeDir.Readdir(-1)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "could not read image storage info: %v", err)
+	}
+
+	var inodes uint64
+	var bytes int64
+	// assume no sub directories there as we store images our particular way
+	for _, fi := range fii {
+		inodes++
+		bytes += fi.Size()
+	}
+	// add directory info as well
+	inodes++
+	bytes += fi.Size()
+
+	fsUsage := &k8s.FilesystemUsage{
+		Timestamp: time.Now().UnixNano(),
+		FsId: &k8s.FilesystemIdentifier{
+			Mountpoint: mount,
+		},
+		UsedBytes: &k8s.UInt64Value{
+			Value: uint64(bytes),
+		},
+		InodesUsed: &k8s.UInt64Value{
+			Value: inodes,
+		},
+	}
+
+	return &k8s.ImageFsInfoResponse{
+		ImageFilesystems: []*k8s.FilesystemUsage{fsUsage},
+	}, nil
 }
 
 // loadInfo reads backup file and restores registry according to it.
@@ -218,4 +268,37 @@ func (s *SingularityRegistry) dumpInfo() error {
 		return fmt.Errorf("could not encode image  %v", err)
 	}
 	return nil
+}
+
+// mountPoint parses mountinfo and returns the path of the parent
+// mount point where provided path is mounted in
+func mountPoint(path string) (string, error) {
+	const (
+		mountInfoPath = "/proc/self/mountinfo"
+		defaultRoot   = "/"
+	)
+
+	p, err := os.Open(mountInfoPath)
+	if err != nil {
+		return "", fmt.Errorf("could not open %s: %v", mountInfoPath, err)
+	}
+	defer p.Close()
+
+	var mountPoints []string
+	scanner := bufio.NewScanner(p)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		mountPoints = append(mountPoints, fields[4])
+	}
+
+	for path != defaultRoot {
+		for _, point := range mountPoints {
+			if point == path {
+				return point, nil
+			}
+		}
+		path = filepath.Dir(path)
+	}
+
+	return defaultRoot, nil
 }


### PR DESCRIPTION
Since all pulled images are stored in a single directory, image filesystem usage info is simply how much memory and inodes that directory consumes. 

Closes #9.