### PR TITLE
Set cgroup paths for pods and containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ To build server you can use Makefile:
 make build
 ```
 
-This will produce the _sycri_ binary with CRI server implementation appear in a bin directory.
+This will build the _sycri_ binary with CRI server implementation and _sycri-selinux_ with SELinux support.
+All the binaries may be found in a bin directory.
 
 To start CRI server simply run _sycri_ binary. By default CRI listens for requests on
 `unix:///var/run/singularity.sock` and stores image files at `/var/lib/singularity`. This behaviour may be configured
@@ -86,7 +87,6 @@ To test CRI in interactive mode we suggest the following workflow:
 
 3. Build and launch CRI server:
 	 ```bash
-	make clean && 
 	make && 
 	sudo PATH=$PATH ./bin/sycri
 	```

--- a/pkg/kube/container_oci.go
+++ b/pkg/kube/container_oci.go
@@ -220,6 +220,7 @@ func (t *containerTranslator) configureResources() {
 	res := t.cont.GetLinux().GetResources()
 	t.g.SetLinuxResourcesCPUMems(res.GetCpusetMems())
 	t.g.SetLinuxResourcesCPUCpus(res.GetCpusetCpus())
+	t.g.SetLinuxCgroupsPath(t.pod.GetLinux().GetCgroupParent())
 
 	if res.GetCpuPeriod() != 0 {
 		t.g.SetLinuxResourcesCPUPeriod(uint64(res.GetCpuPeriod()))

--- a/pkg/kube/pod_files.go
+++ b/pkg/kube/pod_files.go
@@ -17,7 +17,6 @@ package kube
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -128,22 +127,11 @@ func (p *Pod) addResolvConf() error {
 }
 
 func (p *Pod) addHostname() error {
-	var err error
-	hostname := p.GetHostname()
-	if hostname == "" {
-		hostname, err = os.Hostname()
-		if err != nil {
-			return fmt.Errorf("could not get default hostname: %v", err)
-		}
-		log.Printf("setting pod hostname to default value %q", hostname)
-		p.Hostname = hostname
-	}
-
 	host, err := os.OpenFile(p.hostnameFilePath(), os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		return fmt.Errorf("could not create %s: %v", podHostnamePath, err)
 	}
-	fmt.Fprintln(host, hostname)
+	fmt.Fprintln(host, p.GetHostname())
 	if err = host.Close(); err != nil {
 		return fmt.Errorf("could not close %s: %v", podHostnamePath, err)
 	}

--- a/pkg/kube/pod_oci.go
+++ b/pkg/kube/pod_oci.go
@@ -73,6 +73,7 @@ func (t *podTranslator) translate() (*specs.Spec, error) {
 		return nil, err
 	}
 
+	t.g.SetLinuxCgroupsPath(t.pod.GetLinux().GetCgroupParent())
 	t.g.SetRootReadonly(security.GetReadonlyRootfs())
 	t.g.SetProcessUID(uint32(security.GetRunAsUser().GetValue()))
 	t.g.SetProcessGID(uint32(security.GetRunAsGroup().GetValue()))


### PR DESCRIPTION
Missing cgroups setup is added, so that:
1) if pod's cgroup parent is not specified, a new cgroup will be created
2) all containers within a pod are controlled by the same cgroup

Also a bit of refactoring: all default values that are set in pod config are set in a single place upon config validation. README is updated according to recent changes in Makefile.