### PR TITLE
Fix runtime nil pointer panic

### DIFF
--- a/pkg/kube/container_runtime.go
+++ b/pkg/kube/container_runtime.go
@@ -112,7 +112,9 @@ func (c *Container) kill() error {
 	// We should call it when sync socket will no longer be used, and
 	// since multiple calls are fine with cancel func, call it at
 	// the end of kill.
-	defer c.syncCancel()
+	if c.syncCancel != nil {
+		defer c.syncCancel()
+	}
 
 	if c.runtimeState == runtime.StateExited {
 		return nil

--- a/pkg/kube/pod_runtime.go
+++ b/pkg/kube/pod_runtime.go
@@ -109,7 +109,9 @@ func (p *Pod) terminate(force bool) error {
 	// We should call it when sync socket will no longer be used, and
 	// since multiple calls are fine with cancel func, call it at
 	// the end of terminate.
-	defer p.syncCancel()
+	if p.syncCancel != nil {
+		defer p.syncCancel()
+	}
 
 	if p.runtimeState == runtime.StateExited {
 		return nil


### PR DESCRIPTION
The defer call to cancel sync socket context implied that container process has already been started, but that is not always true. Executin nil function led to panic.