### PR TITLE
Quote container command arguments that contain spaces

### DIFF
--- a/pkg/kube/container_oci.go
+++ b/pkg/kube/container_oci.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -256,6 +257,11 @@ func (t *containerTranslator) configureProcess() error {
 	t.g.SetProcessTerminal(t.cont.GetTty())
 
 	args := append(t.cont.GetCommand(), t.cont.GetArgs()...)
+	for i, arg := range args {
+		if strings.ContainsRune(arg, ' ') {
+			args[i] = strconv.Quote(arg)
+		}
+	}
 	t.g.SetProcessArgs(append([]string{runScript}, args...))
 
 	security := t.cont.GetLinux().GetSecurityContext()


### PR DESCRIPTION
This PR is a fix for common case when container command is executed in a shell. 
As an example, the following will not work without quoting: `"command": ["sh", "-c", "touch test.go && [ -f test.go ] && echo 'Found'"]` .