### PR TITLE
Remove unused linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,6 @@ lint:
 	--enable=deadcode \
 	--enable=ineffassign \
 	--enable=golint \
-	--enable=unused \
 	--deadline=3m ./...
 
 dep:


### PR DESCRIPTION
Gometalinter latest commit removed this linter so it should be removed from Makefile as well.